### PR TITLE
切断時に video タグの初期化処理を追加する

### DIFF
--- a/displaymedia.html
+++ b/displaymedia.html
@@ -34,6 +34,7 @@
           options.signalingKey = signalingKey;
         }
         options.audio.enabled = false;
+        const localVideo = document.querySelector('#local-video');
         const remoteVideo = document.querySelector('#remote-video');
         let conn;
         const disconnect = () => {
@@ -44,13 +45,17 @@
         const startConn = async () => {
           conn = Ayame.connection(signalingUrl, roomId, options, true);
           const mediaStream = await navigator.mediaDevices.getDisplayMedia({video: true});
-          conn.on('disconnect', (e) => console.log(e));
+          conn.on('disconnect', (e) => {
+            console.log(e);
+            localVideo.srcObject = null;
+            remoteVideo.srcObject = null;
+          });
           conn.on('addstream', async (e) => {
             console.log(e.stream);
             remoteVideo.srcObject = e.stream;
           });
           await conn.connect(mediaStream, null);
-          document.querySelector('#local-video').srcObject = mediaStream;
+          localVideo.srcObject = mediaStream;
         };
         document.querySelector("#roomIdInput").value = roomId;
         document.querySelector("#clientIdInput").value = options.clientId;

--- a/recvonly.html
+++ b/recvonly.html
@@ -41,6 +41,7 @@
         }
         options.video.direction = 'recvonly';
         options.audio.direction = 'recvonly';
+        const remoteVideo = document.querySelector('#remote-video');
         let conn;
         const disconnect = () => {
           if (conn) {
@@ -52,9 +53,12 @@
           conn = Ayame.connection(signalingUrl, roomId, options, true);
           await conn.connect(null);
           conn.on('open', ({authzMetadata}) => console.log(authzMetadata));
-          conn.on('disconnect', (e) => console.log(e));
+          conn.on('disconnect', (e) => {
+            console.log(e);
+            remoteVideo.srcObject = null;
+          });
           conn.on('addstream', (e) => {
-            document.querySelector('#remote-video').srcObject = e.stream;
+            remoteVideo.srcObject = e.stream;
           });
         };
         document.querySelector("#roomIdInput").value = roomId;

--- a/sendonly.html
+++ b/sendonly.html
@@ -38,9 +38,11 @@
         options.clientId = clientId ? clientId : options.clientId;
         if (signalingKey) {
           options.signalingKey = signalingKey;
+          console.log(options.signalingKey);
         }
         options.video.direction = 'sendonly';
         options.audio.direction = 'sendonly';
+        const localVideo = document.querySelector('#local-video');
         let conn;
         const disconnect = () => {
           if(conn) {
@@ -51,9 +53,12 @@
           options.video.codec = videoCodec;
           conn = Ayame.connection(signalingUrl, roomId, options, true);
           const mediaStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
-          conn.on('disconnect', (e) => console.log(e));
+          conn.on('disconnect', (e) => {
+            console.log(e);
+            localVideo.srcObject = null;
+          });
           await conn.connect(mediaStream, null);
-          document.querySelector('#local-video').srcObject = mediaStream;
+          localVideo.srcObject = mediaStream;
         };
         document.querySelector("#roomIdInput").value = roomId;
         document.querySelector("#clientIdInput").value = options.clientId;

--- a/sendrecv.html
+++ b/sendrecv.html
@@ -42,6 +42,7 @@
         if (signalingKey) {
           options.signalingKey = signalingKey;
         }
+        const localVideo = document.querySelector('#local-video');
         const remoteVideo = document.querySelector('#remote-video');
         let conn;
         const disconnect = () => {
@@ -55,13 +56,17 @@
           const mediaStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true})
           const authnMetadata = {hoge: "fuga"};
           conn.on('open', ({authzMetadata}) => console.log(authzMetadata));
-          conn.on('disconnect', (e) => console.log(e));
+          conn.on('disconnect', (e) => {
+            console.log(e);
+            localVideo.srcObject = null;
+            remoteVideo.srcObject = null;
+          });
           conn.on('addstream', async (e) => {
             console.log(e.stream);
             remoteVideo.srcObject = e.stream;
           });
           await conn.connect(mediaStream, { authnMetadata });
-          document.querySelector('#local-video').srcObject = mediaStream;
+          localVideo.srcObject = mediaStream;
         };
         document.querySelector("#roomIdInput").value = roomId;
         document.querySelector("#clientIdInput").value = options.clientId;


### PR DESCRIPTION
connection 切断後も HTML 上の video タグに stream が設定されたままになっていたため、切断と接続を繰り返すと挙動がおかしくなっていました。
切断時に参照を外すように処理を追加して、切断と接続を繰り返しても動作するように修正しました。